### PR TITLE
Update Alvin

### DIFF
--- a/src/assets/data/pets.json
+++ b/src/assets/data/pets.json
@@ -299,7 +299,7 @@
             "pity": 10000000,
             "equipped": {
                 "bonuses": {
-                    "fermenting_exp": 0.001,
+                    "poop": 0.005,
                     "milk": 0.0025
                 }
             },


### PR DESCRIPTION
I don't know if the original data was wrong or if his bonus has just changed since then, but he now gives poop + milk bonuses:

![image](https://github.com/zy4m/fapi-pets/assets/9273049/8f2915c2-5923-46b7-95b2-adf6a42ccc1a)
